### PR TITLE
Do not retrieved closed shards

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,10 @@ KinesisStream.prototype.getShardIds = function(cb) {
   var self = this
   request('DescribeStream', {StreamName: self.name}, self.options, function(err, res) {
     if (err) return cb(err)
-    cb(null, res.StreamDescription.Shards.map(function(shard) { return shard.ShardId }))
+    cb(null, res.StreamDescription.Shards
+      .filter(function(shard) { return !(shard.SequenceNumberRange && shard.SequenceNumberRange.EndingSequenceNumber) })
+      .map(function(shard) { return shard.ShardId })
+    )
   })
 }
 


### PR DESCRIPTION
At the moment, the lib will return shards even if they are closed which is not desirable as you can't stream from a closed shard obviously. The only way to detect if a shard is closed is verifying if there is an ending sequence number, see http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/kinesis/model/SequenceNumberRange.html#getEndingSequenceNumber()

> The ending sequence number for the range. Shards that are in the OPEN state have an ending sequence number of null.