### PR TITLE
Adds backoffTime option to throttle on getRecords

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,11 @@ KinesisStream.prototype.drainBuffer = function() {
     if (self.shards.every(function(shard) { return shard.ended }))
       return self.push(null)
 
-    self.drainBuffer()
+    if (self.options.backoffTime) {
+      setTimeout(self.drainBuffer.bind(self), self.options.backoffTime)
+    } else {
+      self.drainBuffer()
+    }
   })
 }
 


### PR DESCRIPTION
By getting records immediately after a successful `GetRecords` call there is the
potentially starving other Kinesis consumers on the stream. This change adds an
optional `backoffTime` (ms) option that sleeps before getting records again.